### PR TITLE
winStepの連勝数更新ロジックを修正

### DIFF
--- a/DecompositionMonteCarloMM.mqh
+++ b/DecompositionMonteCarloMM.mqh
@@ -56,7 +56,9 @@ private:
 /*── WIN ──*/
    void winStep(){
       int n = ArraySize(seq);
-      if(n==2 && seq[0]==0 && seq[1]==1) streak++; else streak=0;
+      // 条件成立時は連勝数+1、不成立時は現状維持
+      if(n==2 && seq[0]==0 && seq[1]==1)
+         streak++;
 
       if(n==2){ seq[0]=0; seq[1]=1; }
       else if(n==3){
@@ -71,7 +73,7 @@ private:
 /*── LOSE ──*/
    void loseStep(){
       if(streak>=5) stock += 3;
-      streak = 0;
+      streak = 0; // 敗北時は連勝数リセット
 
       Ins(seq,ArraySize(seq), seq[0]+seq[ArraySize(seq)-1]);
       if(seq[0]==0) avgA(); else avgB();      // ← ここも if/else


### PR DESCRIPTION
## 概要
- 勝利時の条件判定が成立した場合のみ連勝数を加算
- 敗北処理に連勝数リセットのコメントを追加

## テスト
- `rg streak`


------
https://chatgpt.com/codex/tasks/task_e_688f2d41e3408327b6b12fc4f313c6f6