### PR TITLE
連敗時のストック加算ロジックを修正

### DIFF
--- a/DecompositionMonteCarloMM.mqh
+++ b/DecompositionMonteCarloMM.mqh
@@ -77,8 +77,8 @@ private:
 
 /*── LOSE ──*/
    void loseStep(){
-      if(streak>=5) stock += 3;
-      streak = 0; // 敗北時は連勝数リセット
+      if(streak>=6) stock += 4*streak - 21; // 連勝数が6以上ならストック加算
+      streak = 0;                            // 敗北時は連勝数リセット
 
       Ins(seq,ArraySize(seq), seq[0]+seq[ArraySize(seq)-1]);
       if(seq[0]==0) avgA(); else avgB();      // ← ここも if/else


### PR DESCRIPTION
## 概要
- 連敗ステップにおいて6連勝以上時のみ `4*streak - 21` 分のストックを加算するよう変更
- 既定の勝敗パターンに対し、数列推移が `Correct.md` と一致することを確認

## テスト
- `python` スクリプトで勝敗パターン1・2の数列推移を検証


------
https://chatgpt.com/codex/tasks/task_e_688f304e6de08327a61c379384c0d50e