### PR TITLE
簡素化: loseStepのストック消費処理

### DIFF
--- a/DecompositionMonteCarloMM.mqh
+++ b/DecompositionMonteCarloMM.mqh
@@ -83,13 +83,11 @@ private:
       Ins(seq,ArraySize(seq), seq[0]+seq[ArraySize(seq)-1]);
       if(seq[0]==0) avgA(); else avgB();      // ← ここも if/else
 
-      /* ストック消費：先頭 0 化し idx1 へ移動 */
+      /* ストック消費：先頭のみ 0 化 */
       if(seq[0]<=stock && ArraySize(seq)>=2){
          int use = seq[0];
-         stock  -= use;
-         seq[0]  = 0;
-         seq[1] += use;
-         avgA();                               // 整列
+         stock  -= use;                        // ストックから差し引く
+         seq[0]  = 0;                          // 先頭を 0 に設定
       }
 
       if(seq[0]>0){ zeroGen(); avgA(); }


### PR DESCRIPTION
## 概要
- ストック消費処理から `seq[1]+=use;` と `avgA();` を除去
- ストックから差し引きつつ先頭のみを0化する簡素な処理に変更

## テスト
- `echo "no tests" && true`

------
https://chatgpt.com/codex/tasks/task_e_688f3427fa94832782257b0cf0ea53f8