### PR TITLE
zeroGenの早期終了と整形条件の調整

### DIFF
--- a/DecompositionMonteCarloMM.mqh
+++ b/DecompositionMonteCarloMM.mqh
@@ -48,14 +48,14 @@ private:
       // 残り要素より少ない場合は2番目へ加算のみ
       if(red<sub){
          seq[1] += red;
+         return;                                 // 加算のみで終了
       }else{
          long tot = red; for(int i=1;i<ArraySize(seq);i++) tot += seq[i];
          int q = (int)(tot / sub), r = (int)(tot % sub);
          Erase(seq,0); for(int i=0;i<ArraySize(seq);i++) seq[i]=q;
          if(r) seq[0]+=r; Ins(seq,0,0);
+         avgA();                                 // 数列整形を完結
       }
-
-      avgA();                                    // 数列整形を完結
    }
 
    int gm()const{ return (streak<=1)?1:(streak==2)?1:(streak==3)?2:(streak==4)?3:5; }


### PR DESCRIPTION
## 概要
- zeroGen() で残量が少ない場合は2番目へ加算後に即終了するよう修正
- red>=sub の場合のみ avgA() を呼び出すように整理

## テスト
- `python` Correct.md の勝敗パターン1・2を入力して数列推移を確認

------
https://chatgpt.com/codex/tasks/task_e_688f3f6cf26883278d9778c97f8bf5be