### PR TITLE
ストック消費条件の修正

### DIFF
--- a/DecompositionMonteCarloMM.mqh
+++ b/DecompositionMonteCarloMM.mqh
@@ -90,7 +90,7 @@ private:
       if(seq[0]==0) avgA(); else avgB();      // ← ここも if/else
 
       /* ストック消費：先頭のみ 0 化 */
-      if(seq[0]<=stock && ArraySize(seq)>=2){
+      if(seq[0]<=stock){
          int use = seq[0];
          stock  -= use;                        // ストックから差し引く
          seq[0]  = 0;                          // 先頭を 0 に設定


### PR DESCRIPTION
## Summary
- loseStep のストック消費条件から配列サイズ判定を削除

## Testing
- Correct.mdの勝敗パターン1・2をPythonで再現し、数列推移が変化しないことを確認

------
https://chatgpt.com/codex/tasks/task_e_688f437cb3b48327931cb52e6e541812