### PR TITLE
連勝数管理ロジックの修正

### DIFF
--- a/DecompositionMonteCarloMM.mqh
+++ b/DecompositionMonteCarloMM.mqh
@@ -61,7 +61,9 @@ private:
 
 /*── WIN ──*/
    void winStep(){
-      int n = ArraySize(seq);
+      // 勝敗前の数列が基本形か判定
+      int  n    = ArraySize(seq);
+      bool base = (n==2 && seq[0]==0 && seq[n-1]==1);
 
       if(n==2){
          seq[0]=0; seq[1]=1;
@@ -81,11 +83,9 @@ private:
 
       if(seq[0]==0) avgA(); else avgB();      // ← if/else で呼び出し
 
-      // 連勝数の更新：最終シーケンスが基本形なら加算、それ以外はリセット
-      if(ArraySize(seq)==2 && seq[0]==0 && seq[1]==1)
+      // 連勝数の更新：勝敗前が基本形なら加算
+      if(base)
          streak++;
-      else
-         streak = 1;
    }
 
 /*── LOSE ──*/


### PR DESCRIPTION
## 概要
- WIN時の連勝数の更新条件を原著ロジックに合わせて修正

## テスト
- `python - <<'PY' ...` (勝敗パターン1,2で数列推移を確認)


------
https://chatgpt.com/codex/tasks/task_e_68a0cc8da70883279944b77b7fd6dbdd